### PR TITLE
Show unwatched episodes

### DIFF
--- a/Plex/source/MetadataUtils.brs
+++ b/Plex/source/MetadataUtils.brs
@@ -43,8 +43,22 @@ Function createBaseMetadata(container, item, thumb=invalid) As Object
         server = GetPlexMediaServer(item@machineIdentifier)
     end if
 
+    ' Get leafCount and viewedLeafCount information in order to calculate number of unwatched episodes
+    if item@leafCount <> invalid then
+    metadata.LeafCount = firstOf(item@leafCount,"0").toInt()
+    metadata.viewedLeafCount = firstOf(item@viewedLeafCount,"0").toInt() 
+    metadata.totalUnwatched = metadata.LeafCount - metadata.viewedLeafCount
+    else 
+    metadata.totalUnwatched = 0
+    end if
+    'Debug("totalUnwatched = "+tostr(metadata.totalUnwatched))
+    if metadata.totalUnwatched > 0 then
+    metadata.Title = firstOf(item@title, item@name)+" ("+tostr(metadata.totalUnwatched)+")"
+    else 
     metadata.Title = firstOf(item@title, item@name)
-
+    end if
+    
+    
     ' There is a *massive* performance problem on grid views if the description
     ' isn't truncated.
     metadata.Description = truncateString(item@summary, 250, invalid)

--- a/Plex/source/ViewController.brs
+++ b/Plex/source/ViewController.brs
@@ -4,7 +4,7 @@
 '* recreating views and breadcrumbs. It also provides a single place that
 '* can take an item and figure out which type of screen should be shown
 '* so that logic doesn't have to be in each individual screen type.
-'*T
+'*
 
 Function createViewController() As Object
     controller = CreateObject("roAssociativeArray")

--- a/Plex/source/ViewController.brs
+++ b/Plex/source/ViewController.brs
@@ -4,7 +4,7 @@
 '* recreating views and breadcrumbs. It also provides a single place that
 '* can take an item and figure out which type of screen should be shown
 '* so that logic doesn't have to be in each individual screen type.
-'*
+'*T
 
 Function createViewController() As Object
     controller = CreateObject("roAssociativeArray")


### PR DESCRIPTION
This mod modifies the metadata title by adding the number of unwatched shows in parentheses after the title if a Series or Season has unwatched episodes, otherwise it doesn't put anything. Something to note, on the season and video poster screens, the number won't update until you go back to grid view.  I'll look into dynamically updating those if it's not too much of a performance issue.
This also shows the unwatched number in the breadcrumbs area.  
