### PR TITLE
Playlist Support

### DIFF
--- a/Plex/source/AudioSpringboardScreen.brs
+++ b/Plex/source/AudioSpringboardScreen.brs
@@ -187,7 +187,9 @@ Function audioHandleMessage(msg) As Boolean
                     end if
                 end if
 
-                dialog.SetButton("rate", "_rate_")
+                if m.metadata.mediaContainerIdentifier = "com.plexapp.plugins.library" then
+                    dialog.SetButton("rate", "_rate_")
+                end if
                 if m.metadata.server.AllowsMediaDeletion AND m.metadata.mediaContainerIdentifier = "com.plexapp.plugins.library" then
                     dialog.SetButton("delete", "Delete permanently")
                 end if
@@ -300,7 +302,7 @@ Function audioDialogHandleButton(command, data) As Boolean
         Debug("audioHandleMessage:: Rate audio for key " + tostr(obj.metadata.ratingKey))
         rateValue% = (data /10)
         obj.metadata.UserRating = data
-        if obj.metadata.ratingKey <> invalid then
+        if obj.metadata.ratingKey <> invalid and obj.metadata.mediaContainerIdentifier <> invalid then
             obj.Item.server.Rate(obj.metadata.ratingKey, obj.metadata.mediaContainerIdentifier, rateValue%.ToStr())
         end if
     else if command = "close" then

--- a/Plex/source/HomeScreenDataLoader.brs
+++ b/Plex/source/HomeScreenDataLoader.brs
@@ -98,6 +98,7 @@ Sub homeSetupRows()
         { title: "Library Sections", key: "sections", style: "square", visibility_key: "row_visibility_sections", account_required: false },
         { title: "On Deck", key: "on_deck", style: "portrait", visibility_key: "row_visibility_ondeck", account_required: false },
         { title: "Recently Added", key: "recently_added", style: "portrait", visibility_key: "row_visibility_recentlyadded", account_required: false },
+        { title: "Playlists", key: "playlists", style: "square", visibility_key: "row_visibility_playlists", account_required: false },
         { title: "Queue", key: "queue", style: "landscape", visibility_key: "playlist_view_queue", account_required: true },
         { title: "Recommendations", key: "recommendations", style: "landscape", visibility_key: "playlist_view_recommendations", account_required: true },
         { title: "Shared Library Sections", key: "shared_sections", style: "square", visibility_key: "row_visibility_shared_sections", account_required: true },
@@ -206,6 +207,14 @@ Sub homeCreateServerRequests(server As Object, startRequests As Boolean)
         recents.key = "/library/recentlyAdded"
         recents.requestType = "media"
         m.AddOrStartRequest(recents, m.RowIndexes["recently_added"], startRequests)
+    end if
+    ' Request playlists
+    if m.RowIndexes["playlists"] >= 0 then
+        playlists = CreateObject("roAssociativeArray")
+        playlists.server = server
+        playlists.key = "/playlists"
+        playlists.requestType = "media"
+        m.AddOrStartRequest(playlists, m.RowIndexes["playlists"], startRequests)
     end if
 End Sub
 
@@ -718,6 +727,10 @@ Function homeGetPlaceholder(row, empty)
         dummy.paragraphs.Push("Either you don't have a Plex Media Server running or it couldn't be reached.")
         dummy.paragraphs.Push("Plex Media Server can be installed on your computer from https://plex.tv/downloads")
         dummy.paragraphs.Push("If you'll never use Channels, you can hide this row under Preferences -> Home Screen")
+    else if row = m.RowIndexes["playlists"] then
+        dummy.Title = "No Playlists"
+        dummy.header = dummy.Title
+        dummy.paragraphs.Push("No playlists found.")
     else if row = m.RowIndexes["on_deck"] then
         dummy.Title = "No On Deck Items"
         dummy.header = dummy.Title

--- a/Plex/source/MetadataUtils.brs
+++ b/Plex/source/MetadataUtils.brs
@@ -87,8 +87,10 @@ Function createBaseMetadata(container, item, thumb=invalid) As Object
     end if
 
     sizes = ImageSizes(container.ViewGroup, item@type)
+
+
     if thumb = invalid then
-        thumb = firstOf(item@thumb, item@parentThumb, item@grandparentThumb, container.xml@thumb)
+        thumb = firstOf(item@thumb, item@parentThumb, item@grandparentThumb, container.xml@thumb, item@composite)
     end if
 
     if thumb <> invalid AND thumb <> "" AND server <> invalid then

--- a/Plex/source/PlaylistsMetadata.brs
+++ b/Plex/source/PlaylistsMetadata.brs
@@ -1,0 +1,7 @@
+
+Function newPlaylistsMetadata(container, item) As Object
+    playlists = createBaseMetadata(container, item)
+    playlists.ContentType = item@type
+    return playlists
+End Function
+

--- a/Plex/source/PlexContainer.brs
+++ b/Plex/source/PlexContainer.brs
@@ -122,6 +122,8 @@ Sub containerParseXml()
             metadata = newPhotoMetadata(m, n, m.ParseDetails)
         else if n.GetName() = "Setting" then
             metadata = newSettingMetadata(m, n)
+        else if nodeType = "playlist" then
+            metadata = newPlaylistsMetadata(m, n)
         else
             metadata = newDirectoryMetadata(m, n)
         end if

--- a/Plex/source/PosterScreen.brs
+++ b/Plex/source/PosterScreen.brs
@@ -240,7 +240,9 @@ Sub posterActivate(priorScreen)
     status = m.contentArray[m.focusedList]
     if status = invalid or status.lastUpdatedSize = invalid or status.content = invalid then return
 
-    if status.lastUpdatedSize <> status.content.Count() then
+    'SAH - still need some work here for 'shuffle'
+    if status.lastUpdatedSize <> status.content.Count() or status.forcusedIndex <> priorScreen.CurIndex then
+        status.focusedIndex = priorScreen.CurIndex
         m.ShowList(m.focusedList)
         status.lastUpdatedSize = status.content.Count()
     end if

--- a/Plex/source/ViewController.brs
+++ b/Plex/source/ViewController.brs
@@ -188,6 +188,10 @@ Function vcCreateScreenForItem(context, contextIndex, breadcrumbs, show=true) As
     else if contentType = "playlists" then
         screen = createGridScreenForItem(item, m, "landscape")
         screenName = "Playlist Grid"
+    else if contentType = "playlist" then
+        screen = createPosterScreen(item, m)
+        screen.SetListStyle("flat-episodic", "zoom-to-fill")
+        screenName = "Playlist Grid"
     else if contentType = "photo" then
         if right(item.key, 8) = "children" then
             screen = createPosterScreen(item, m)

--- a/Plex/source/generalUtils.brs
+++ b/Plex/source/generalUtils.brs
@@ -343,11 +343,12 @@ End Function
 '******************************************************
 'Return the first valid argument
 '******************************************************
-Function firstOf(first, second, third=invalid, fourth=invalid)
+Function firstOf(first, second, third=invalid, fourth=invalid, fifth=invalid)
     if first <> invalid then return first
     if second <> invalid then return second
     if third <> invalid then return third
-    return fourth
+    if fourth <> invalid then return fourth
+    return fifth
 End Function
 
 '******************************************************


### PR DESCRIPTION
I took a stab at adding some basic Playlist play support to the Roku client. This is the first time I've looked at the Roku client code and am sure I've made some mistakes.

Added a "Playlists" main menu item. 

Used the 'collection' thumbnail image for represent the playlist items.

![roku_playlist1](https://cloud.githubusercontent.com/assets/884816/4024016/17f8b110-2bb3-11e4-8350-dded3ab182b2.jpg)
![roku_playlist2](https://cloud.githubusercontent.com/assets/884816/4024018/1d585674-2bb3-11e4-98ab-1f23a2343fa9.jpg)

I've test with the QNAP (Intel) Plex Server version 0.9.9.14.5. Created the Playlists on the server side then accessed them via the Roku client.
